### PR TITLE
bundler を2.1.4　にダウングレードしてgem.lockを変更

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,7 +290,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  x86_64-darwin-20
+  ruby
 
 DEPENDENCIES
   annotate
@@ -326,4 +326,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.2.8
+   2.1.4


### PR DESCRIPTION
heroku 20から18に変更後にデプロイしたら、エラー。
 Detecting rake tasks と出たので、rubyのビルドに問題あり。
herokuのbondlerとrailsのbundlerのバージョンが違うので合わせてみることにする。